### PR TITLE
Reduce standard version requirement from C++14 to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ set(
 # ----------------------------------------------------------------------------------------
 #                         ===== Compiler Configuration =====
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 
 # CUDA_CONFIG
 if (CMAKE_CUDA_COMPILER)

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -219,8 +219,9 @@ Tile::Tile(const OpInfo *info, SCAMPArchitecture arch, int cuda_id)
           static_cast<double *>(
               alloc_mem<double>(info->max_tile_ts_size, arch, cuda_id)),
           [=](double *p) { return free_mem<double>(p, arch, cuda_id); }),
-      _scratch(std::make_unique<qt_compute_helper>(info->max_tile_ts_size,
-                                                   info->mp_window, true, arch))
+
+      _scratch(std::unique_ptr<qt_compute_helper>( new qt_compute_helper(info->max_tile_ts_size,
+                                                   info->mp_window, true, arch)))
 #ifdef _HAS_CUDA_
       ,
       _stream(),


### PR DESCRIPTION
Since the onlye feature of C++14 in use is one usage of make_unique. It worths to
keep the standard version requirement as C++11 until some other features
are used.