### PR TITLE
Silent mode

### DIFF
--- a/src/SCAMP.cpp
+++ b/src/SCAMP.cpp
@@ -12,7 +12,9 @@
 #include "SCAMP.h"
 #include "common.h"
 #include "cpu_stats.h"
+#include "scamp_exception.h"
 #include "tile.h"
+
 using std::vector;
 
 namespace SCAMP {
@@ -25,7 +27,10 @@ void SCAMP_Operation::get_tiles() {
                               static_cast<double>(_info.max_tile_height));
   size_t num_tile_cols = ceil((_info.full_ts_len_A - _info.mp_window + 1) /
                               static_cast<double>(_info.max_tile_width));
-  printf("num_tile_rows = %lu, cols = %lu\n", num_tile_rows, num_tile_cols);
+  if (!_info.silent_mode) {
+    printf("num_tile_rows = %lu, cols = %lu\n", num_tile_rows, num_tile_cols);
+  }
+
   if (_info.self_join) {
     for (int offset = 0; offset < num_tile_rows - 1; ++offset) {
       for (int diag = 0; diag < num_tile_cols - 1 - offset; ++diag) {
@@ -109,10 +114,12 @@ void SCAMP_Operation::do_work(const std::vector<double> &timeseries_a,
                                  _info.full_ts_len_A - tile.get_tile_col()));
     tile.set_tile_height(std::min(_info.max_tile_ts_size,
                                   _info.full_ts_len_B - tile.get_tile_row()));
-    std::cout << "Starting tile with starting row of " << tile.get_tile_row()
-              << " starting column of " << tile.get_tile_col()
-              << " with height " << tile.get_tile_height() << " and width "
-              << tile.get_tile_width() << std::endl;
+    if (!_info.silent_mode) {
+      std::cout << "Starting tile with starting row of " << tile.get_tile_row()
+                << " starting column of " << tile.get_tile_col()
+                << " with height " << tile.get_tile_height() << " and width "
+                << tile.get_tile_width() << std::endl;
+    }
     // Copy the portion of the time series and stats
     //  we will be using from the global arrays.
     tile.InitTimeseries(timeseries_a, timeseries_b);
@@ -151,7 +158,9 @@ void SCAMP_Operation::do_work(const std::vector<double> &timeseries_a,
 SCAMPError_t SCAMP_Operation::do_join(const std::vector<double> &timeseries_a,
                                       const std::vector<double> &timeseries_b) {
   const int num_workers = _cpu_workers + _devices.size();
-  printf("Num workers = %d\n", num_workers);
+  if (!_info.silent_mode) {
+    printf("Num workers = %d\n", num_workers);
+  }
 
   std::vector<double> timeseries_a_clean, timeseries_b_clean;
   std::vector<bool> nanvals_a, nanvals_b;
@@ -174,8 +183,10 @@ SCAMPError_t SCAMP_Operation::do_join(const std::vector<double> &timeseries_a,
   // Populate Work Queue with tiles
   get_tiles();
 
-  std::cout << "Performing join with " << _work_queue.size() << " tiles."
-            << std::endl;
+  if (!_info.silent_mode) {
+    std::cout << "Performing join with " << _work_queue.size() << " tiles."
+              << std::endl;
+  }
   std::vector<std::future<void>> futures(num_workers);
 
   // Start CUDA Workers
@@ -205,13 +216,14 @@ SCAMPError_t SCAMP_Operation::do_join(const std::vector<double> &timeseries_a,
 void do_SCAMP(SCAMPArgs *args, const std::vector<int> &devices,
               int num_threads) {
   if (devices.empty() && num_threads <= 0) {
-    printf("Error: no compute_resources provided\n");
-    exit(0);
+    throw SCAMPException("Error: no compute_resources provided");
   }
-  if (args == nullptr || !args->valid()) {
-    printf("Error: invalid arguments provided to SCAMP\n");
-    exit(0);
+  if (args == nullptr) {
+    throw SCAMPException("Error: Invalid arguments provided to SCAMP");
+  } else {
+    args->validate();
   }
+
   // Allocate and initialize memory
   OptionalArgs _opt_args(args->distance_threshold);
   // Construct operation
@@ -222,7 +234,7 @@ void do_SCAMP(SCAMPArgs *args, const std::vector<int> &devices,
       args->distributed_start_row, args->distributed_start_col, _opt_args,
       args->profile_type, &args->profile_a, &args->profile_b,
       args->keep_rows_separate, args->computing_rows, args->computing_columns,
-      args->is_aligned, num_threads);
+      args->is_aligned, args->silent_mode, num_threads);
   // Execute op
   std::chrono::high_resolution_clock::time_point start =
       std::chrono::high_resolution_clock::now();
@@ -233,14 +245,16 @@ void do_SCAMP(SCAMPArgs *args, const std::vector<int> &devices,
   }
   std::chrono::high_resolution_clock::time_point end =
       std::chrono::high_resolution_clock::now();
-  printf(
-      "Finished %d SCAMP tiles to generate  matrix profile in %lf "
-      "seconds on %lu devices and %d threads\n",
-      op.get_completed_tiles(),
-      std::chrono::duration_cast<std::chrono::microseconds>(end - start)
-              .count() /
-          static_cast<double>(1000000),
-      devices.size(), num_threads);
+  if (!args->silent_mode) {
+    printf(
+        "Finished %d SCAMP tiles to generate  matrix profile in %lf "
+        "seconds on %lu devices and %d threads\n",
+        op.get_completed_tiles(),
+        std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+                .count() /
+            static_cast<double>(1000000),
+        devices.size(), num_threads);
+  }
 }
 
 }  // namespace SCAMP

--- a/src/SCAMP.h
+++ b/src/SCAMP.h
@@ -1,8 +1,10 @@
 #pragma once
+
 #include <list>
 #include <unordered_map>
 #include <vector>
 #include "common.h"
+
 using std::list;
 using std::pair;
 using std::unordered_map;
@@ -59,17 +61,19 @@ class SCAMP_Operation {
                   int64_t start_col, OptionalArgs args_,
                   SCAMPProfileType profile_type, Profile *pA, Profile *pB,
                   bool keep_rows, bool compute_rows, bool compute_cols,
-                  bool is_aligned, int num_threads)
+                  bool is_aligned, bool silent_mode, int num_threads)
       : _info(Asize, Bsize, window_sz, max_tile_size, selfjoin, t, start_row,
               start_col, args_, profile_type, keep_rows, compute_rows,
-              compute_cols, is_aligned, dev.size() + num_threads),
+              compute_cols, is_aligned, silent_mode, dev.size() + num_threads),
         _completed_tiles(0),
         _profile_a(pA),
         _profile_b(pB),
         _devices(dev),
         _cpu_workers(num_threads) {}
+
   SCAMPError_t do_join(const std::vector<double> &timeseries_a,
                        const std::vector<double> &timeseries_b);
+
   int get_completed_tiles() { return _completed_tiles; }
 };
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,29 +1,26 @@
 #include "common.h"
+#include "scamp_exception.h"
 
 #include <cstdlib>
+#include <sstream>
 
-bool SCAMP::SCAMPArgs::valid() {
+void SCAMP::SCAMPArgs::validate() {
   if (window < 3) {
-    printf("Error: Subsequence length must be at least 3\n");
-    return false;
+    throw SCAMPException("Error: Subsequence length must be at least 3");
   }
-  if (max_tile_size < 1034) {
-    printf("Error: max tile size must be at least 1024\n");
-    return false;
+  if (max_tile_size < 1024) {
+    throw SCAMPException("Error: max tile size must be at least 1024");
   }
   if (max_tile_size / 2 < window) {
-    printf(
+    throw SCAMPException(
         "Error: Tile length and width must be at least 2x larger than the "
-        "window size\n");
-    return false;
+        "window size");
   }
   if (timeseries_a.size() < window || (has_b && timeseries_b.size() < window)) {
-    printf(
+    throw SCAMPException(
         "Error: Input time series must be at least 'subesequence window size' "
-        "in length\n");
-    return false;
+        "in length");
   }
-  return true;
 }
 
 size_t SCAMP::GetProfileTypeSize(SCAMPProfileType t) {
@@ -35,20 +32,18 @@ size_t SCAMP::GetProfileTypeSize(SCAMPProfileType t) {
     case PROFILE_TYPE_1NN:
       return sizeof(float);
     default:
-      printf("Error: Could not determine size of profile elements");
-      exit(1);
-      return 0;
+      throw SCAMPException(
+          "Error: Could not determine size of profile elements");
   }
 }
 
 #ifdef _HAS_CUDA_
 void gpuAssert(cudaError_t code, const char *file, int line, bool abort) {
   if (code != cudaSuccess) {
-    fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file,
-            line);
-    if (abort) {
-      exit(code);
-    }
+    std::ostringstream ostream;
+    ostream << "GPUasssert: " << cudaGetErrorString(code) << " " << file << " "
+            << line;
+    throw SCAMPException(ostream.str());
   }
 }
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <sstream>
 #include <unordered_map>
 
 namespace SCAMP {
@@ -62,7 +63,8 @@ struct Profile {
 // Arguments for a SCAMP operation
 // This is an external user's interface to the SCAMP library
 struct SCAMPArgs {
-  bool valid();
+  void validate();
+
   std::vector<double> timeseries_a;
   std::vector<double> timeseries_b;
   Profile profile_a;
@@ -79,6 +81,7 @@ struct SCAMPArgs {
   bool computing_columns;
   bool keep_rows_separate;
   bool is_aligned;
+  bool silent_mode;
 };
 
 // Struct describing kernel arguments which are non-standard
@@ -99,7 +102,7 @@ struct OpInfo {
          bool selfjoin, SCAMPPrecisionType t, int64_t start_row,
          int64_t start_col, OptionalArgs args_, SCAMPProfileType profiletype,
          bool keep_rows, bool compute_rows, bool compute_cols, bool aligned,
-         int num_workers)
+         bool silent_mode, int num_workers)
       : full_ts_len_A(Asize),
         full_ts_len_B(Bsize),
         mp_window(window_sz),
@@ -112,7 +115,8 @@ struct OpInfo {
         keep_rows_separate(keep_rows),
         computing_rows(compute_rows),
         computing_cols(compute_cols),
-        is_aligned(aligned) {
+        is_aligned(aligned),
+        silent_mode(silent_mode) {
     if (self_join) {
       full_ts_len_B = full_ts_len_A;
     }
@@ -123,6 +127,7 @@ struct OpInfo {
     max_tile_width = max_tile_ts_size - mp_window + 1;
     max_tile_height = max_tile_width;
   }
+
   // Type of profile to compute
   SCAMPProfileType profile_type;
 
@@ -161,6 +166,8 @@ struct OpInfo {
   // Determines if we should keep the row/column matrix profiles separate or to
   // merge them.
   bool keep_rows_separate;
+  // Run without printing any message by standard output
+  bool silent_mode;
 };
 
 // Struct containing the precomputed statistics for an input time series
@@ -172,21 +179,22 @@ struct PrecomputedInfo {
   std::vector<double> _means;
 
  public:
-  void set(std::vector<double>& means, std::vector<double>& norms,
-           std::vector<double>& df, std::vector<double>& dg) {
+  void set(std::vector<double> &means, std::vector<double> &norms,
+           std::vector<double> &df, std::vector<double> &dg) {
     _norms = std::move(norms);
     _means = std::move(means);
     _df = std::move(df);
     _dg = std::move(dg);
   }
-  const std::vector<double>& dg() const { return _dg; }
-  const std::vector<double>& df() const { return _df; }
-  const std::vector<double>& norms() const { return _norms; }
-  const std::vector<double>& means() const { return _means; }
-  std::vector<double>& mutable_dg() { return _dg; }
-  std::vector<double>& mutable_df() { return _df; }
-  std::vector<double>& mutable_norms() { return _norms; }
-  std::vector<double>& mutable_means() { return _means; }
+
+  const std::vector<double> &dg() const { return _dg; }
+  const std::vector<double> &df() const { return _df; }
+  const std::vector<double> &norms() const { return _norms; }
+  const std::vector<double> &means() const { return _means; }
+  std::vector<double> &mutable_dg() { return _dg; }
+  std::vector<double> &mutable_df() { return _df; }
+  std::vector<double> &mutable_norms() { return _norms; }
+  std::vector<double> &mutable_means() { return _means; }
 };
 
 // Thread safe queue to hold tiles to be executed
@@ -214,14 +222,14 @@ class ThreadSafeQueue {
     return item;
   }
 
-  void push(const std::pair<int, int>& item) {
+  void push(const std::pair<int, int> &item) {
     std::unique_lock<std::mutex> mlock(mutex_);
     queue_.push(item);
     mlock.unlock();
     cond_.notify_one();
   }
 
-  void push(std::pair<int, int>&& item) {
+  void push(std::pair<int, int> &&item) {
     std::unique_lock<std::mutex> mlock(mutex_);
     queue_.push(std::move(item));
     mlock.unlock();
@@ -234,7 +242,7 @@ class ThreadSafeQueue {
   std::condition_variable cond_;
 };
 
-using DeviceProfile = std::unordered_map<int, void*>;
+using DeviceProfile = std::unordered_map<int, void *>;
 
 // Returns the size in bytes of a the matrix profile element for a particular MP
 // type
@@ -267,16 +275,17 @@ enum SCAMPTileType {
 }  // namespace SCAMP
 
 #ifdef _HAS_CUDA_
-void gpuAssert(cudaError_t code, const char* file, int line, bool abort = true);
+void gpuAssert(cudaError_t code, const char *file, int line, bool abort = true);
 #define gpuErrchk(ans) \
   { gpuAssert((ans), __FILE__, __LINE__); }
 #endif
 
-#define ASSERT(condition, message)                                       \
-  do {                                                                   \
-    if (!(condition)) {                                                  \
-      std::cerr << "Assertion `" #condition "` failed in " << __FILE__   \
-                << " line " << __LINE__ << ": " << message << std::endl; \
-      std::terminate();                                                  \
-    }                                                                    \
+#define ASSERT(condition, message)                                         \
+  do {                                                                     \
+    if (!(condition)) {                                                    \
+      std::ostringstream ostream;                                          \
+      ostream << "Assertion `" << #condition << "` failed in " << __FILE__ \
+              << "line " << __LINE__;                                      \
+      throw SCAMPException(ostream.str());                                 \
+    }                                                                      \
   } while (false)

--- a/src/kernels.cu
+++ b/src/kernels.cu
@@ -545,11 +545,15 @@ int get_smem(const OpInfo *info, uint64_t blocksz) {
              intermediate_data_size;
   int profile_data_size = GetProfileTypeSize(info->profile_type);
   if (info->computing_cols) {
-    printf("computing cols\n");
+    if (!info->silent_mode) {
+      printf("computing cols\n");
+    }
     smem += tile_width * profile_data_size;
   }
   if (info->computing_rows) {
-    printf("computing rows\n");
+    if (!info->silent_mode) {
+      printf("computing rows\n");
+    }
     smem += tile_height * profile_data_size;
   }
   return smem;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,9 @@
 #ifdef _HAS_CUDA_
+
 #include <cuda_runtime.h>
+
 #endif
+
 #include <gflags/gflags.h>
 #include <cmath>
 #include <fstream>
@@ -12,6 +15,7 @@
 #include <vector>
 #include "SCAMP.h"
 #include "common.h"
+#include "scamp_exception.h"
 
 DEFINE_int32(num_cpu_workers, 0, "Number of CPU workers to use");
 DEFINE_bool(output_pearson, false,
@@ -380,11 +384,17 @@ int main(int argc, char **argv) {
   args.is_aligned = FLAGS_aligned;
   args.timeseries_a = std::move(Ta_h);
   args.timeseries_b = std::move(Tb_h);
+  args.silent_mode = false;
 
   InitProfileMemory(&args);
 
   printf("Starting SCAMP\n");
-  SCAMP::do_SCAMP(&args, devices, FLAGS_num_cpu_workers);
+  try {
+    SCAMP::do_SCAMP(&args, devices, FLAGS_num_cpu_workers);
+  } catch (const SCAMPException &e) {
+    std::cout << e.what() << "\n";
+    exit(1);
+  }
 
   printf("Now writing result to files\n");
   WriteProfileToFile(FLAGS_output_a_file_name, FLAGS_output_a_index_file_name,

--- a/src/qt_helper.cpp
+++ b/src/qt_helper.cpp
@@ -1,14 +1,50 @@
-#ifdef _HAS_CUDA
+#ifdef _HAS_CUDA_
 #include <cuda_runtime.h>
 #include <cufft.h>
-#endif
-
-#include "qt_helper.h"
-#ifdef _HAS_CUDA_
 #include "qt_kernels.h"
 #endif
+#include "qt_helper.h"
 
 namespace SCAMP {
+
+void qt_compute_helper::init() {
+  if (_arch == CUDA_GPU_WORKER) {
+#ifdef _HAS_CUDA_
+    cufft_data_size = size / 2 + 1;
+    if (double_precision) {
+      CHECK_CUFFT_ERRORS(cufftPlan1d(&fft_plan, size, CUFFT_D2Z, 1))
+      CHECK_CUFFT_ERRORS(cufftPlan1d(&ifft_plan, size, CUFFT_Z2D, 1))
+    } else {
+      CHECK_CUFFT_ERRORS(cufftPlan1d(&fft_plan, size, CUFFT_R2C, 1))
+      CHECK_CUFFT_ERRORS(cufftPlan1d(&ifft_plan, size, CUFFT_C2R, 1))
+    }
+    cudaMalloc(&Q_reverse_pad, sizeof(double) * size);
+    gpuErrchk(cudaPeekAtLastError())
+        cudaMalloc(&Tc, sizeof(cuDoubleComplex) * cufft_data_size);
+    gpuErrchk(cudaPeekAtLastError())
+        cudaMalloc(&Qc, sizeof(cuDoubleComplex) * cufft_data_size);
+    gpuErrchk(cudaPeekAtLastError())
+#else
+    ASSERT(false,
+           "Attempted to use GPU resources in a binary not built with cuda");
+#endif
+  }
+}
+
+void qt_compute_helper::free() {
+  if (_arch == CUDA_GPU_WORKER) {
+#ifdef _HAS_CUDA_
+    cudaFree(Q_reverse_pad);
+    gpuErrchk(cudaPeekAtLastError()) cudaFree(Tc);
+    gpuErrchk(cudaPeekAtLastError()) cudaFree(Qc);
+    gpuErrchk(cudaPeekAtLastError()) CHECK_CUFFT_ERRORS(cufftDestroy(fft_plan))
+        CHECK_CUFFT_ERRORS(cufftDestroy(ifft_plan))
+#else
+    ASSERT(false,
+           "Attempted to use GPU resources in a binary not built with cuda");
+#endif
+  }
+}
 
 SCAMPError_t qt_compute_helper::compute_QT_CPU(double *QT, const double *T,
                                                const double *Q) {
@@ -41,42 +77,50 @@ SCAMPError_t qt_compute_helper::compute_QT(double *QT, const double *T,
 
   const int n = size - window_size + 1;
 
-  CHECK_CUFFT_ERRORS(cufftSetStream(fft_plan, s));
+  try {
+    init();
+    CHECK_CUFFT_ERRORS(cufftSetStream(fft_plan, s))
 
-  CHECK_CUFFT_ERRORS(cufftSetStream(ifft_plan, s));
-  // Compute the FFT of the time series
-  // For some reason the input parameter to cufftExecD2Z is not held const by
-  // cufft
-  // I see nowhere in the documentation that the input vector is modified
-  // using const_cast as a hack to get around this...
-  CHECK_CUFFT_ERRORS(
-      cufftExecD2Z(fft_plan, const_cast<double *>(T), Tc));  // NOLINT
+    CHECK_CUFFT_ERRORS(cufftSetStream(ifft_plan, s))
+    // Compute the FFT of the time series
+    // For some reason the input parameter to cufftExecD2Z is not held const
+    // by cufft I see nowhere in the documentation that the input vector is
+    // modified using const_cast as a hack to get around this...
+    CHECK_CUFFT_ERRORS(
+        cufftExecD2Z(fft_plan, const_cast<double *>(T), Tc))  // NOLINT
 
-  // Reverse and zero pad the query
-  launch_populate_reverse_pad(Q, Q_reverse_pad, qmeans, window_size, size,
-                              fft_work_size, s);
-  error = cudaPeekAtLastError();
-  if (error != cudaSuccess) {
-    return SCAMP_CUDA_ERROR;
-  }
+    // Reverse and zero pad the query
+    launch_populate_reverse_pad(Q, Q_reverse_pad, qmeans, window_size, size,
+                                fft_work_size, s);
+    error = cudaPeekAtLastError();
+    if (error != cudaSuccess) {
+      free();
+      return SCAMP_CUDA_ERROR;
+    }
 
-  CHECK_CUFFT_ERRORS(cufftExecD2Z(fft_plan, Q_reverse_pad, Qc));
+    CHECK_CUFFT_ERRORS(cufftExecD2Z(fft_plan, Q_reverse_pad, Qc))
 
-  launch_elementwise_multiply_inplace(Tc, Qc, cufft_data_size, fft_work_size,
-                                      s);
-  error = cudaPeekAtLastError();
-  if (error != cudaSuccess) {
-    return SCAMP_CUDA_ERROR;
-  }
+    launch_elementwise_multiply_inplace(Tc, Qc, cufft_data_size, fft_work_size,
+                                        s);
+    error = cudaPeekAtLastError();
+    if (error != cudaSuccess) {
+      free();
+      return SCAMP_CUDA_ERROR;
+    }
 
-  CHECK_CUFFT_ERRORS(cufftExecZ2D(ifft_plan, Qc, Q_reverse_pad));
+    CHECK_CUFFT_ERRORS(cufftExecZ2D(ifft_plan, Qc, Q_reverse_pad))
 
-  launch_normalized_aligned_dot_products(Q_reverse_pad, size, window_size, n,
-                                         QT, fft_work_size, s);
-  error = cudaPeekAtLastError();
+    launch_normalized_aligned_dot_products(Q_reverse_pad, size, window_size, n,
+                                           QT, fft_work_size, s);
+    error = cudaPeekAtLastError();
 
-  if (error != cudaSuccess) {
-    return SCAMP_CUDA_ERROR;
+    if (error != cudaSuccess) {
+      free();
+      return SCAMP_CUDA_ERROR;
+    }
+  } catch (SCAMPException &e) {
+    free();
+    throw e;
   }
   return SCAMP_NO_ERROR;
 }

--- a/src/qt_helper.h
+++ b/src/qt_helper.h
@@ -6,7 +6,10 @@
 
 #include <stdlib.h>
 #include "common.h"
+#include "scamp_exception.h"
+
 #ifdef _CUFFT_H_
+
 // cuFFT API errors
 static const char *_cudaGetErrorEnum(cufftResult error) {
   switch (error) {
@@ -44,17 +47,20 @@ static const char *_cudaGetErrorEnum(cufftResult error) {
       return "CUFFT_NOT_SUPPORTED";
     case CUFFT_INCOMPLETE_PARAMETER_LIST:
       return "CUFFT_INCOMPLETE_PARAMETER_LIST";
+    default:
+      return "CUFFT UNKNOWN ERROR";
   }
 }
 
-#define CHECK_CUFFT_ERRORS(call)                           \
-  {                                                        \
-    cufftResult_t err;                                     \
-    if ((err = (call)) != CUFFT_SUCCESS) {                 \
-      fprintf(stderr, "cuFFT error %d:%s at %s:%d\n", err, \
-              _cudaGetErrorEnum(err), __FILE__, __LINE__); \
-      exit(1);                                             \
-    }                                                      \
+#define CHECK_CUFFT_ERRORS(call)                                        \
+  {                                                                     \
+    cufftResult_t err;                                                  \
+    if ((err = (call)) != CUFFT_SUCCESS) {                              \
+      std::ostringstream ostream;                                       \
+      ostream << "cuFFT error " << err << ":" << _cudaGetErrorEnum(err) \
+              << " at " << __FILE__ << ":" << __LINE__;                 \
+      throw SCAMPException(ostream.str());                              \
+    }                                                                   \
   }
 #endif
 
@@ -74,49 +80,24 @@ class qt_compute_helper {
   size_t cufft_data_size;
   const int fft_work_size = 512;
 #endif
+
+  void init();
+  void free();
+
  public:
   qt_compute_helper(size_t sz, size_t window_sz, bool dp,
                     SCAMPArchitecture arch)
-      : size(sz), window_size(window_sz), double_precision(dp), _arch(arch) {
-    if (arch == CUDA_GPU_WORKER) {
+      : size(sz), window_size(window_sz), double_precision(dp), _arch(arch) {}
+
 #ifdef _HAS_CUDA_
-      cufft_data_size = sz / 2 + 1;
-      if (double_precision) {
-        CHECK_CUFFT_ERRORS(cufftPlan1d(&fft_plan, size, CUFFT_D2Z, 1));
-        CHECK_CUFFT_ERRORS(cufftPlan1d(&ifft_plan, size, CUFFT_Z2D, 1));
-      } else {
-        CHECK_CUFFT_ERRORS(cufftPlan1d(&fft_plan, size, CUFFT_R2C, 1));
-        CHECK_CUFFT_ERRORS(cufftPlan1d(&ifft_plan, size, CUFFT_C2R, 1));
-      }
-      cudaMalloc(&Q_reverse_pad, sizeof(double) * size);
-      gpuErrchk(cudaPeekAtLastError());
-      cudaMalloc(&Tc, sizeof(cuDoubleComplex) * cufft_data_size);
-      gpuErrchk(cudaPeekAtLastError());
-      cudaMalloc(&Qc, sizeof(cuDoubleComplex) * cufft_data_size);
-      gpuErrchk(cudaPeekAtLastError());
-#else
-      ASSERT(false,
-             "Attempted to use GPU resources in a binary not built with cuda");
-#endif
-    }
-  }
-#ifdef _HAS_CUDA_
-  ~qt_compute_helper() {
-    if (_arch == CPU_WORKER) {
-      return;
-    }
-    cudaFree(Q_reverse_pad);
-    gpuErrchk(cudaPeekAtLastError());
-    cudaFree(Tc);
-    gpuErrchk(cudaPeekAtLastError());
-    cudaFree(Qc);
-    gpuErrchk(cudaPeekAtLastError());
-    CHECK_CUFFT_ERRORS(cufftDestroy(fft_plan));
-    CHECK_CUFFT_ERRORS(cufftDestroy(ifft_plan));
-  }
+
+  ~qt_compute_helper() {}
+
   SCAMPError_t compute_QT(double *QT, const double *T, const double *Q,
                           const double *qmeans, cudaStream_t s);
+
 #endif
+
   SCAMPError_t compute_QT_CPU(double *QT, const double *T, const double *Q);
 };
 

--- a/src/scamp_exception.h
+++ b/src/scamp_exception.h
@@ -1,0 +1,24 @@
+#ifndef SCAMP_SCAMP_EXCEPTION_H
+#define SCAMP_SCAMP_EXCEPTION_H
+
+#include <exception>
+#include <string>
+
+class SCAMPException : public std::exception {
+ public:
+  SCAMPException(std::string message) : _msg(std::move(message)) {}
+
+  virtual ~SCAMPException() {}
+
+  SCAMPException(const SCAMPException& copyFrom) = default;
+  SCAMPException& operator=(const SCAMPException& copyFrom) = default;
+  SCAMPException(SCAMPException&&) = default;
+  SCAMPException& operator=(SCAMPException&&) = default;
+
+  virtual const char* what() const noexcept { return _msg.c_str(); }
+
+ protected:
+  std::string _msg;
+};
+
+#endif  // SCAMP_SCAMP_EXCEPTION_H


### PR DESCRIPTION
Add silent mode and throw instead of exiting

The silent_mode option has been added to the SCAMPArgs struct. If this option is set to true (false by default) the execution will not print to the standard output.

The error handling method has been changed. The pointes where exit or terminate were being called now throw an exception which is handled from main.

The error checking done for allocation and deallocation in the constructor and destructor of qt_compute_helper have been moved to specific functions that are called at the begin and end of the qt computation. It is necessary to avoid throwing from the destructor.