### PR TITLE
Fixes to compile for 5.0 compute capability devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,12 @@ if (CMAKE_CUDA_COMPILER)
   set_target_properties(gpu_kernels PROPERTIES
     COMPILE_FLAGS "${COMPILE_FLAGS} ${CUDA_GENCODE_FLAGS}"
   )
+  set_target_properties(qt_kernels PROPERTIES
+    COMPILE_FLAGS "${COMPILE_FLAGS} ${CUDA_GENCODE_FLAGS}"
+  )
+  set_target_properties(gpu_utils PROPERTIES
+    COMPILE_FLAGS "${COMPILE_FLAGS} ${CUDA_GENCODE_FLAGS}"
+  )
 endif()
 
 # C++/CUDA executable

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,8 @@
 #include "scamp_exception.h"
 #include "scamp_utils.h"
 
+#include "helper_cuda.h"
+
 #ifdef _DISTRIBUTED_EXECUTION_
 #include "../kubernetes/scamp_interface.h"
 #endif
@@ -99,6 +101,8 @@ DEFINE_string(gpus, "",
               "tries to use all available GPUs on the system");
 
 int main(int argc, char **argv) {
+
+  findCudaDevice(argc, (const char **)argv);
   bool self_join, computing_rows, computing_cols;
   size_t start_row = 0;
   size_t start_col = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,6 @@
 #include "scamp_exception.h"
 #include "scamp_utils.h"
 
-#include "helper_cuda.h"
-
 #ifdef _DISTRIBUTED_EXECUTION_
 #include "../kubernetes/scamp_interface.h"
 #endif
@@ -101,8 +99,6 @@ DEFINE_string(gpus, "",
               "tries to use all available GPUs on the system");
 
 int main(int argc, char **argv) {
-
-  findCudaDevice(argc, (const char **)argv);
   bool self_join, computing_rows, computing_cols;
   size_t start_row = 0;
   size_t start_col = 0;

--- a/src/qt_helper.cpp
+++ b/src/qt_helper.cpp
@@ -87,7 +87,6 @@ SCAMPError_t qt_compute_helper::compute_QT(double *QT, const double *T,
   // For some reason the input parameter to cufftExecD2Z is not held const
   // by cufft I see nowhere in the documentation that the input vector is
   // modified using const_cast as a hack to get around this...
-  //
   CHECK_CUFFT_ERRORS(
       cufftExecD2Z(fft_plan, const_cast<double *>(T), Tc))  // NOLINT
 

--- a/src/qt_helper.cpp
+++ b/src/qt_helper.cpp
@@ -93,7 +93,6 @@ SCAMPError_t qt_compute_helper::compute_QT(double *QT, const double *T,
 
   // clear last error
   error = cudaGetLastError();
-  printf("Clearing error before execute: %s\n", cudaGetErrorString(error));
 
   // Reverse and zero pad the query
   launch_populate_reverse_pad(Q, Q_reverse_pad, qmeans, window_size, size,

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -143,11 +143,10 @@ T *alloc_mem(size_t count, SCAMPArchitecture arch, int deviceid) {
   switch (arch) {
     case CUDA_GPU_WORKER: {
 #ifdef _HAS_CUDA_
-      cudaSetDevice(deviceid);
-      gpuErrchk(cudaPeekAtLastError());
+      gpuErrchk(cudaSetDevice(deviceid));
       size_t bytes = count * sizeof(T);
       T *ptr;
-      cudaMalloc(&ptr, bytes);
+      gpuErrchk(cudaMalloc(&ptr, bytes));
       gpuErrchk(cudaPeekAtLastError());
       return ptr;
 #else
@@ -166,10 +165,8 @@ void free_mem(T *ptr, SCAMPArchitecture arch, int deviceid) {
   switch (arch) {
     case CUDA_GPU_WORKER:
 #ifdef _HAS_CUDA_
-      cudaSetDevice(deviceid);
-      gpuErrchk(cudaPeekAtLastError());
-      cudaFree(ptr);
-      gpuErrchk(cudaPeekAtLastError());
+      gpuErrchk(cudaSetDevice(deviceid));
+      gpuErrchk(cudaFree(ptr));
 #else
       ASSERT(false, "Using CUDA in binary not built with it");
 #endif
@@ -184,10 +181,8 @@ void Tile::Memset(void *destination, char value, size_t bytes) {
   switch (get_arch()) {
     case CUDA_GPU_WORKER:
 #ifdef _HAS_CUDA_
-      cudaSetDevice(get_cuda_id());
-      gpuErrchk(cudaPeekAtLastError());
-      cudaMemsetAsync(destination, value, bytes, get_stream());
-      gpuErrchk(cudaPeekAtLastError());
+      gpuErrchk(cudaSetDevice(get_cuda_id()));
+      gpuErrchk(cudaMemsetAsync(destination, value, bytes, get_stream()));
 #else
       ASSERT(false, "Using CUDA in binary not built with it");
 #endif


### PR DESCRIPTION
The compile flags were missing for `qt_kernels` and `gpu_utils` which means any CUDA code there wasn't getting compiled for all compute capability levels. This resulted in `no kernel image` errors despite having sufficient compute capability.

In addition, in some places, `cudaPeekAtLastError` was used, which only needs to be used when launching a kernel, not when doing an operation that can actually return a value such as `cudaFree` etc.

This had resulted in getting a `no kernel image` error within the `free_mem` section, as that was where the previously mentioned issue actually surfaced.