### PR TITLE
Automate pyscamp versioning to match the git version of SCAMP. 

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        ref: master
         submodules: 'true'
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: master
         submodules: 'true'
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,15 +1,12 @@
 name: Upload Python Package
 
 on:
-  workflow_run:
-    workflows: ["Build and Test"]
-    branches: [master]
-    types: [completed]
+  release:
+    types: [released]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -29,4 +26,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        skip_existing: true

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,12 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pyscamp',
-    version='0.6.1',
+    use_scm_version = {
+        "root": ".",
+        "relative_to": __file__,
+        "local_scheme": "no-local-version"
+    },
+    setup_requires=['setuptools_scm'],
     author='Zachary Zimmerman',
     author_email='zpzimmerman@gmail.com',
     description='SCAlable Matrix Profile',


### PR DESCRIPTION
Only publish pyscamp on a new release of SCAMP.