### PR TITLE
Add benchmarks for CPU Kernels

### DIFF
--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -38,11 +38,11 @@ jobs:
           mkdir build && cd build
           cmake -DBUILD_BENCHMARKS=1 ..
           cmake --build . --config Release --parallel 2
-          if [ -f "./Release/src/scamp_benchmarks.exe" ]; then
-            cp ./Release/src/scamp_benchmarks.exe .
+          if [ -f "./Release/src/benchmark/scamp_benchmarks.exe" ]; then
+            cp ./Release/src/benchmark/scamp_benchmarks.exe .
           fi
       - name: Run Benchmarks
-        run: ./src/scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
+        run: ./src/benchmark/scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -38,11 +38,11 @@ jobs:
           mkdir build && cd build
           cmake -DBUILD_BENCHMARKS=1 ..
           cmake --build . --config Release --parallel 2
-          if [ -f "./Release/SCAMP.exe" ]; then
-            cp ./Release/SCAMP.exe .
+          if [ -f "./Release/src/scamp_benchmarks.exe" ]; then
+            cp ./Release/src/scamp_benchmarks.exe .
           fi
       - name: Run Benchmarks
-        run: ./src/scamp_benchmark --benchmark_format=json | tee benchmark_result.json
+        run: ./src/scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -10,12 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        compiler: [g++, clang++, cl]
+        compiler: [g++, clang++, cl, clang-cl]
         exclude:
           - os: ubuntu-latest
             compiler: cl
+          - os: ubuntu-latest
+            compiler: clang-cl
           - os: macos-latest
             compiler: cl
+          - os: macos-latest
+            compiler: clang-cl
           - os: windows-latest
             compiler: g++
           - os: windows-latest
@@ -36,13 +40,17 @@ jobs:
           set -e
           cd $GITHUB_WORKSPACE
           mkdir build && cd build
-          cmake -DBUILD_BENCHMARKS=1 ..
+          if [ ${{ matrix.compiler }} = "clang-cl" ]; then
+            cmake -G"Visual Studio 16 2019" -T ClangCL -A x64 -DBUILD_BENCHMARKS=1 .. 
+          else
+            cmake -DBUILD_BENCHMARKS=1 ..
+          fi
           cmake --build . --config Release --parallel 2
           if [ -f "./src/benchmark/scamp_benchmarks" ]; then
             cp ./src/benchmark/scamp_benchmarks .
           fi
-          if [ -f "./Release/src/benchmark/scamp_benchmarks.exe" ]; then
-            cp ./Release/src/benchmark/scamp_benchmarks.exe .
+          if [ -f "./src/benchmark/Release/scamp_benchmarks.exe" ]; then
+            cp ./src/benchmark/Release/scamp_benchmarks.exe .
           fi
       - name: Run Benchmarks
         shell: bash

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - add-benchmarks
 jobs:
   benchmark:
     strategy:
@@ -71,10 +70,8 @@ jobs:
           # Separate Dashboard for each combination of OS/Compiler
           benchmark-data-dir-path: cpu-benchmarks/${{ matrix.os }}/${{ matrix.compiler }}/bench
           auto-push: true
-          # Workflow will fail when an alert happens
           fail-on-alert: true
           comment-on-alert: true
-          comment-always: true
           alert-threshold: "150%"
           alert-comment-cc-users: '@zpzim'
       # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -1,0 +1,69 @@
+name: CPU Benchmarks
+on:
+  push:
+    branches:
+      - master
+      - add-benchmarks
+jobs:
+  benchmark:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        compiler: [g++, clang++, cl]
+        exclude:
+          - os: ubuntu-latest
+            compiler: cl
+          - os: macos-latest
+            compiler: cl
+          - os: windows-latest
+            compiler: g++
+          - os: windows-latest
+            compiler: clang++
+
+
+    name: CPU Benchmarks
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Prep Build
+        run: echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
+      - name: Build SCAMP Benchmarks
+        shell: bash
+        run: |
+          set -e
+          cd $GITHUB_WORKSPACE
+          mkdir build && cd build
+          cmake -DBUILD_BENCHMARKS=1 ..
+          cmake --build . --config Release --parallel 2
+          if [ -f "./Release/SCAMP.exe" ]; then
+            cp ./Release/SCAMP.exe .
+          fi
+      - name: Run Benchmarks
+        run: ./src/scamp_benchmark --benchmark_format=json | tee benchmark_result.json
+
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ matrix.os }}-${{ matrix.compiler }}-benchmark
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.txt came from
+          tool: 'googlecpp'
+          # Where the output from the benchmark tool is stored
+          output-file-path: $GITHUB_WORKSPACE/build/benchmark_result.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          comment-on-alert: true
+          alert-comment-cc-users: '@zpzim'
+      # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -75,7 +75,7 @@ jobs:
           output-file-path: ./build/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Separate Dashboard for each combination of OS/Compiler
-          benchmark-data-dir-path: ${{ matrix.os }}/${{ matrix.compiler }}/bench
+          benchmark-data-dir-path: cpu-benchmarks/${{ matrix.os }}/${{ matrix.compiler }}/bench
           auto-push: true
           # Workflow will fail when an alert happens
           fail-on-alert: true

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -38,6 +38,9 @@ jobs:
           mkdir build && cd build
           cmake -DBUILD_BENCHMARKS=1 ..
           cmake --build . --config Release --parallel 2
+          if [ -f "./src/benchmark/scamp_benchmarks" ]; then
+            cp ./src/benchmark/scamp_benchmarks .
+          fi
           if [ -f "./Release/src/benchmark/scamp_benchmarks.exe" ]; then
             cp ./Release/src/benchmark/scamp_benchmarks.exe .
           fi
@@ -46,7 +49,7 @@ jobs:
         run: |
           set -e
           cd $GITHUB_WORKSPACE/build
-          ./src/benchmark/scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
+          ./scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -42,7 +42,10 @@ jobs:
             cp ./Release/src/benchmark/scamp_benchmarks.exe .
           fi
       - name: Run Benchmarks
-        run: ./src/benchmark/scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
+        run: |
+          set -e
+          cd $GITHUB_WORKSPACE/build
+          ./src/benchmark/scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -59,12 +59,6 @@ jobs:
           cd $GITHUB_WORKSPACE/build
           ./scamp_benchmarks --benchmark_format=json | tee benchmark_result.json
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ matrix.os }}-${{ matrix.compiler }}-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -80,5 +74,7 @@ jobs:
           # Workflow will fail when an alert happens
           fail-on-alert: true
           comment-on-alert: true
+          comment-always: true
+          alert-threshold: "150%"
           alert-comment-cc-users: '@zpzim'
       # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -60,7 +60,7 @@ jobs:
           # What benchmark tool the output.txt came from
           tool: 'googlecpp'
           # Where the output from the benchmark tool is stored
-          output-file-path: $GITHUB_WORKSPACE/build/benchmark_result.json
+          output-file-path: ./build/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Where the previous data file is stored

--- a/.github/workflows/cpu-benchmarks.yml
+++ b/.github/workflows/cpu-benchmarks.yml
@@ -42,6 +42,7 @@ jobs:
             cp ./Release/src/benchmark/scamp_benchmarks.exe .
           fi
       - name: Run Benchmarks
+        shell: bash
         run: |
           set -e
           cd $GITHUB_WORKSPACE/build
@@ -62,9 +63,9 @@ jobs:
           # Where the output from the benchmark tool is stored
           output-file-path: ./build/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Separate Dashboard for each combination of OS/Compiler
+          benchmark-data-dir-path: ${{ matrix.os }}/${{ matrix.compiler }}/bench
           auto-push: true
-          # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
           # Workflow will fail when an alert happens
           fail-on-alert: true
           comment-on-alert: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,11 @@ if (BUILD_PYTHON_MODULE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/python)
 endif()
 
+if (BUILD_BENCHMARKS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/benchmark)
+endif()
+
+
 if (BUILD_CLIENT_SERVER)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc EXCLUDE_FROM_ALL)
   message(STATUS "Using gRPC via add_subdirectory.")

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+
+include(FetchContent)
+FetchContent_Declare(benchmark
+  GIT_REPOSITORY    https://github.com/google/benchmark.git
+  GIT_TAG           "v1.6.1"
+)
+
+set(BENCHMARK_DOWNLOAD_DEPENDENCIES 1)
+
+FetchContent_MakeAvailable(benchmark)
+
+
+add_executable(scamp_benchmarks "benchmarks.cpp")
+target_link_libraries(scamp_benchmarks scamp_interface benchmark::benchmark)
+

--- a/src/benchmark/benchmarks.cpp
+++ b/src/benchmark/benchmarks.cpp
@@ -4,13 +4,12 @@
 #include "common/common.h"
 #include "common/scamp_args.h"
 #include "common/scamp_exception.h"
-#include "common/scamp_utils.h"
 #include "common/scamp_interface.h"
-
+#include "common/scamp_utils.h"
 
 double get_random() {
   static std::default_random_engine e;
-  static std::uniform_real_distribution<> dis(0,1);
+  static std::uniform_real_distribution<> dis(0, 1);
   return dis(e);
 }
 
@@ -31,10 +30,9 @@ static void benchmarkArgsCI(benchmark::internal::Benchmark* b) {
 }
 
 static void BM_1NN_INDEX_SELF_JOIN(benchmark::State& state) {
-
   // 128K random vector
-  std::vector<double> ts = get_random_vec(state.range(1));  
-  
+  std::vector<double> ts = get_random_vec(state.range(1));
+
   std::uniform_real_distribution<> dis(0, 1);
 
   SCAMP::SCAMPArgs args;
@@ -65,16 +63,14 @@ static void BM_1NN_INDEX_SELF_JOIN(benchmark::State& state) {
   for (auto _ : state) {
     SCAMP::do_SCAMP(&args, gpu_devices, num_threads);
   }
-
 }
 
 BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Apply(benchmarkArgsCI);
 
 static void BM_1NN_SELF_JOIN(benchmark::State& state) {
-
   // 128K random vector
-  std::vector<double> ts = get_random_vec(state.range(1));  
-  
+  std::vector<double> ts = get_random_vec(state.range(1));
+
   std::uniform_real_distribution<> dis(0, 1);
 
   SCAMP::SCAMPArgs args;
@@ -110,10 +106,9 @@ static void BM_1NN_SELF_JOIN(benchmark::State& state) {
 BENCHMARK(BM_1NN_SELF_JOIN)->Apply(benchmarkArgsCI);
 
 static void BM_SUM_SELF_JOIN(benchmark::State& state) {
-
   // 128K random vector
-  std::vector<double> ts = get_random_vec(state.range(1));  
-  
+  std::vector<double> ts = get_random_vec(state.range(1));
+
   std::uniform_real_distribution<> dis(0, 1);
 
   SCAMP::SCAMPArgs args;

--- a/src/benchmark/benchmarks.cpp
+++ b/src/benchmark/benchmarks.cpp
@@ -1,0 +1,151 @@
+#include <random>
+
+#include <benchmark/benchmark.h>
+#include "common/common.h"
+#include "common/scamp_args.h"
+#include "common/scamp_exception.h"
+#include "common/scamp_utils.h"
+#include "common/scamp_interface.h"
+
+
+double get_random() {
+  static std::default_random_engine e;
+  static std::uniform_real_distribution<> dis(0,1);
+  return dis(e);
+}
+
+std::vector<double> get_random_vec(size_t size) {
+  std::vector<double> out(size);
+  for (int i = 0; i < size; ++i) {
+    out[i] = get_random();
+  }
+  return out;
+}
+
+static void benchmarkArgsCI(benchmark::internal::Benchmark* b) {
+  for (int i = 1; i < 3; ++i) {
+    for (int j = 15; j < 18; ++j) {
+      b->Args({i, 1 << j});
+    }
+  }
+}
+
+static void BM_1NN_INDEX_SELF_JOIN(benchmark::State& state) {
+
+  // 128K random vector
+  std::vector<double> ts = get_random_vec(state.range(1));  
+  
+  std::uniform_real_distribution<> dis(0, 1);
+
+  SCAMP::SCAMPArgs args;
+  args.window = 100;
+  args.max_tile_size = 1 << 17;
+  args.has_b = false;
+  args.distributed_start_row = -1;
+  args.distributed_start_col = -1;
+  args.distance_threshold = -1;
+  args.computing_columns = true;
+  args.computing_rows = true;
+  args.profile_a.type = SCAMP::PROFILE_TYPE_1NN_INDEX;
+  args.profile_b.type = SCAMP::PROFILE_TYPE_1NN_INDEX;
+  args.precision_type = SCAMP::PRECISION_DOUBLE;
+  args.profile_type = SCAMP::PROFILE_TYPE_1NN_INDEX;
+  args.keep_rows_separate = false;
+  args.is_aligned = false;
+  args.timeseries_a = ts;
+  args.timeseries_b = ts;
+  args.silent_mode = true;
+  args.max_matches_per_column = 1;
+  args.matrix_height = 0;
+  args.matrix_width = 0;
+
+  std::vector<int> gpu_devices;
+  int num_threads = state.range(0);
+
+  for (auto _ : state) {
+    SCAMP::do_SCAMP(&args, gpu_devices, num_threads);
+  }
+
+}
+
+BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Apply(benchmarkArgsCI);
+
+static void BM_1NN_SELF_JOIN(benchmark::State& state) {
+
+  // 128K random vector
+  std::vector<double> ts = get_random_vec(state.range(1));  
+  
+  std::uniform_real_distribution<> dis(0, 1);
+
+  SCAMP::SCAMPArgs args;
+  args.window = 100;
+  args.max_tile_size = 1 << 17;
+  args.has_b = false;
+  args.distributed_start_row = -1;
+  args.distributed_start_col = -1;
+  args.distance_threshold = -1;
+  args.computing_columns = true;
+  args.computing_rows = true;
+  args.profile_a.type = SCAMP::PROFILE_TYPE_1NN;
+  args.profile_b.type = SCAMP::PROFILE_TYPE_1NN;
+  args.precision_type = SCAMP::PRECISION_DOUBLE;
+  args.profile_type = SCAMP::PROFILE_TYPE_1NN;
+  args.keep_rows_separate = false;
+  args.is_aligned = false;
+  args.timeseries_a = ts;
+  args.timeseries_b = ts;
+  args.silent_mode = true;
+  args.max_matches_per_column = 1;
+  args.matrix_height = 0;
+  args.matrix_width = 0;
+
+  std::vector<int> gpu_devices;
+  int num_threads = state.range(0);
+
+  for (auto _ : state) {
+    SCAMP::do_SCAMP(&args, gpu_devices, num_threads);
+  }
+}
+
+BENCHMARK(BM_1NN_SELF_JOIN)->Apply(benchmarkArgsCI);
+
+static void BM_SUM_SELF_JOIN(benchmark::State& state) {
+
+  // 128K random vector
+  std::vector<double> ts = get_random_vec(state.range(1));  
+  
+  std::uniform_real_distribution<> dis(0, 1);
+
+  SCAMP::SCAMPArgs args;
+  args.window = 100;
+  args.max_tile_size = 1 << 17;
+  args.has_b = false;
+  args.distributed_start_row = -1;
+  args.distributed_start_col = -1;
+  args.distance_threshold = -1;
+  args.computing_columns = true;
+  args.computing_rows = true;
+  args.profile_a.type = SCAMP::PROFILE_TYPE_SUM_THRESH;
+  args.profile_b.type = SCAMP::PROFILE_TYPE_SUM_THRESH;
+  args.precision_type = SCAMP::PRECISION_DOUBLE;
+  args.profile_type = SCAMP::PROFILE_TYPE_SUM_THRESH;
+  args.keep_rows_separate = false;
+  args.is_aligned = false;
+  args.timeseries_a = ts;
+  args.timeseries_b = ts;
+  args.silent_mode = true;
+  args.max_matches_per_column = 1;
+  args.matrix_height = 0;
+  args.matrix_width = 0;
+
+  std::vector<int> gpu_devices;
+  int num_threads = state.range(0);
+
+  for (auto _ : state) {
+    SCAMP::do_SCAMP(&args, gpu_devices, num_threads);
+  }
+}
+
+BENCHMARK(BM_SUM_SELF_JOIN)->Apply(benchmarkArgsCI);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This PR adds benchmarks for 1NN_INDEX, 1NN, and SUM_THRESH CPU kernels on various operating systems and compilers.

Benchmarks will run automatically whenever a commit is pushed to master and will alert if performance changes significantly.