### PR TITLE
Fix pyscamp sdist to include the appropriate files to build the distribution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,7 +129,8 @@ jobs:
         run: |
           set -e
           cd $GITHUB_WORKSPACE
-          python3 -m pip install .
+          python3 setup.py sdist
+          python3 -m pip install dist/*
           python3 -m pip install numpy pandas tqdm
 
       - name: pyscamp Test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 global-include CMakeLists.txt
 
 graft src
-graft pybind11
-graft gflags
+graft third_party/gflags
+graft third_party/pybind11
+graft third_party/eigen


### PR DESCRIPTION
Also modifies tests to verify the sdist can be built from the archive before a release. Will help address #89 