### PR TITLE
Improve benchmarking to add stable CPU benchmarks and reduce variance on Github runners.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [g++-9, clang++-10]
+        compiler: [g++, clang++]
     name: CPU Benchmarks Stable
     runs-on: self-hosted
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -75,11 +75,10 @@ jobs:
           auto-push: true
           fail-on-alert: false
           comment-on-alert: true
-          alert-threshold: "150%"
+          alert-threshold: "200%"
           alert-comment-cc-users: '@zpzim'
-      # Upload the updated cache file for the next job by actions/cache
 
-  benchmark-ubuntu-stable:
+  benchmark-stable:
     strategy:
       fail-fast: false
       matrix:
@@ -126,7 +125,6 @@ jobs:
           comment-on-alert: true
           alert-threshold: "115%"
           alert-comment-cc-users: '@zpzim'
-      # Upload the updated cache file for the next job by actions/cache
 
   benchmark-gpu:
     name: GPU Benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -73,9 +73,58 @@ jobs:
           # Separate Dashboard for each combination of OS/Compiler
           benchmark-data-dir-path: cpu-benchmarks/${{ matrix.os }}/${{ matrix.compiler }}/bench
           auto-push: true
-          fail-on-alert: true
+          fail-on-alert: false
           comment-on-alert: true
           alert-threshold: "150%"
+          alert-comment-cc-users: '@zpzim'
+      # Upload the updated cache file for the next job by actions/cache
+
+  benchmark-ubuntu-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [g++-9, clang++-10]
+    name: CPU Benchmarks Stable
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Prep Build
+        run: echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
+      - name: Build SCAMP Benchmarks
+        shell: bash
+        run: |
+          set -e
+          cd $GITHUB_WORKSPACE
+          mkdir build && cd build
+          cmake -DBUILD_BENCHMARKS=1 ..
+          cmake --build . --config Release --parallel 2
+          if [ -f "./src/benchmark/scamp_cpu_benchmarks" ]; then
+            cp ./src/benchmark/scamp_cpu_benchmarks .
+          fi
+      - name: Run Benchmarks
+        shell: bash
+        run: |
+          set -e
+          cd $GITHUB_WORKSPACE/build
+          ./scamp_cpu_benchmarks --benchmark_format=json | tee benchmark_result.json
+     
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.txt came from
+          tool: 'googlecpp'
+          # Where the output from the benchmark tool is stored
+          output-file-path: ./build/benchmark_result.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Separate Dashboard for each combination of OS/Compiler
+          benchmark-data-dir-path: cpu-benchmarks/linux-stable/${{ matrix.compiler }}/bench
+          auto-push: true
+          fail-on-alert: false
+          comment-on-alert: true
+          alert-threshold: "115%"
           alert-comment-cc-users: '@zpzim'
       # Upload the updated cache file for the next job by actions/cache
 
@@ -117,5 +166,5 @@ jobs:
           auto-push: true
           fail-on-alert: true
           comment-on-alert: true
-          alert-threshold: "150%"
+          alert-threshold: "115%"
           alert-comment-cc-users: '@zpzim'

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -22,11 +22,10 @@ Benchmarks
 
 SCAMP has automated benchmarks running. Here is a link to recent GPU performance results:
 
- `GPU NVIDIA Tesla P100 (1x), Input length 1M datapoints, default parameters <https://zpzim.github.io/SCAMP/gpu-benchmarks/bench>`_ 
+ `GPU NVIDIA Tesla P100 (1x), Input length 512K datapoints, default parameters <https://zpzim.github.io/SCAMP/gpu-benchmarks/bench>`_ 
+ `CPU: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz, Single Thread, Input length 32K datapoints, default parameters <https://zpzim.github.io/SCAMP/cpu-benchmarks/linux-stable/clang++-10/bench>`_ 
 
-Note that the charts are not totally optimized for human consumption yet. But you can see a benchmark of each profile type, the y-axis is nanoseconds.
-
-More charts will be added here once there are more stable benchmarks for CPU code.
+Note that the charts are not totally optimized for human consumption yet. But you can see a benchmark of each profile type.
 
 Performance Comparisons
 ***********************

--- a/src/benchmark/cpu_benchmarks.cpp
+++ b/src/benchmark/cpu_benchmarks.cpp
@@ -2,12 +2,12 @@
 #include "benchmark/common.h"
 
 static void benchmarkArgsCI(benchmark::internal::Benchmark* b) {
-  b->Args({1, 1 << 17});
+  b->Args({1, 1 << 15});
 }
 
-BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_1NN_SELF_JOIN)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_SUM_SELF_JOIN)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_MATRIX_SELF_JOIN)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_1NN_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_SUM_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_MATRIX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
 
 BENCHMARK_MAIN();

--- a/src/benchmark/cpu_benchmarks.cpp
+++ b/src/benchmark/cpu_benchmarks.cpp
@@ -5,9 +5,13 @@ static void benchmarkArgsCI(benchmark::internal::Benchmark* b) {
   b->Args({1, 1 << 15});
 }
 
-BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_1NN_INDEX_SELF_JOIN)
+    ->Unit(benchmark::kSecond)
+    ->Apply(benchmarkArgsCI);
 BENCHMARK(BM_1NN_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
 BENCHMARK(BM_SUM_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_MATRIX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_MATRIX_SELF_JOIN)
+    ->Unit(benchmark::kSecond)
+    ->Apply(benchmarkArgsCI);
 
 BENCHMARK_MAIN();

--- a/src/benchmark/gpu_benchmarks.cpp
+++ b/src/benchmark/gpu_benchmarks.cpp
@@ -5,9 +5,13 @@ static void benchmarkArgsCI(benchmark::internal::Benchmark* b) {
   b->Args({-1, 1 << 19});
 }
 
-BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_1NN_INDEX_SELF_JOIN)
+    ->Unit(benchmark::kSecond)
+    ->Apply(benchmarkArgsCI);
 BENCHMARK(BM_1NN_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
 BENCHMARK(BM_SUM_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_MATRIX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_MATRIX_SELF_JOIN)
+    ->Unit(benchmark::kSecond)
+    ->Apply(benchmarkArgsCI);
 
 BENCHMARK_MAIN();

--- a/src/benchmark/gpu_benchmarks.cpp
+++ b/src/benchmark/gpu_benchmarks.cpp
@@ -2,12 +2,12 @@
 #include "benchmark/common.h"
 
 static void benchmarkArgsCI(benchmark::internal::Benchmark* b) {
-  b->Args({-1, 1 << 20});
+  b->Args({-1, 1 << 19});
 }
 
-BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_1NN_SELF_JOIN)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_SUM_SELF_JOIN)->Apply(benchmarkArgsCI);
-BENCHMARK(BM_MATRIX_SELF_JOIN)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_1NN_INDEX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_1NN_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_SUM_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
+BENCHMARK(BM_MATRIX_SELF_JOIN)->Unit(benchmark::kSecond)->Apply(benchmarkArgsCI);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Adds a stable version of gcc/clang benchmarks on linux. Also updates benchmarking to run smaller benchmarks which will execute more iterations, this should reduce timing variance.