### PR TITLE
Fix benchmark/docs/PyPI CI issues

### DIFF
--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
     steps:
     - uses: actions/checkout@v4
       with:
@@ -26,6 +28,5 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
     steps:
     - uses: actions/checkout@v4
       with:
@@ -24,5 +26,3 @@ jobs:
       run: python -m build --sdist
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -32,7 +32,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: requirements.txt
     - requirements: docs/requirements.txt
-    - method: pip
-      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "20"
-    # rust: "1.70"
-    # golang: "1.20"
+  environment:
+    # Prevent cmake from searching for CUDA in the RTD build environment
+    FORCE_NO_CUDA: "1"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,9 +13,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-  environment:
-    # Prevent cmake from searching for CUDA in the RTD build environment
-    FORCE_NO_CUDA: "1"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM nvidia/cuda:12.9.0-devel-ubuntu24.04 AS base
 
-# SCAMP build dependencies
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+# SCAMP build dependencies. Skip 'apt-get upgrade' — the base image is
+# already current enough for our needs and upgrading pulls in dozens of
+# unrelated packages (llvm-18 toolchain, libicu, libpython3.12, etc.) which
+# multiply the chance of a transient Ubuntu mirror failure during the build.
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         cmake zlib1g-dev clang \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/pyscamp.py
+++ b/docs/pyscamp.py
@@ -1,0 +1,167 @@
+"""
+pyscamp: Python bindings for SCAMP
+----------------------------------
+
+.. currentmodule:: pyscamp
+
+.. autosummary::
+   :toctree: _generate
+
+   selfjoin
+   abjoin
+   selfjoin_sum
+   abjoin_sum
+   selfjoin_knn
+   abjoin_knn
+   selfjoin_matrix
+   abjoin_matrix
+"""
+
+
+def gpu_supported():
+    """Returns true if both 1) The module was compiled with GPU support and 2) GPUs are available."""
+    ...
+
+
+def selfjoin(a, m, **kwargs):
+    """
+    Computes the matrix profile for time series A.
+
+    :param a: Time series to compute matrix profile for.
+    :type a: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :return: A tuple containing the matrix profile as the first element and the indices as the second element.
+    :rtype: Tuple of np.ndarray[float32] and np.ndarray[int32]
+    """
+    ...
+
+
+def abjoin(a, b, m, **kwargs):
+    """
+    For each subsequence in time series A, finds the nearest neighbor in time series B.
+
+    :param a: Time series, b will be queried for subsequences in a.
+    :type a: 1D array
+    :param b: Time series in which to search for matches for subsequences in a.
+    :type b: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :return: A tuple. First element: The nearest neighbor distance of subsequences in a to time series b. Second element: The index (in b) of each nearest neighbor.
+    :rtype: Tuple of np.ndarray[float32] and np.ndarray[int32]
+    """
+    ...
+
+
+def selfjoin_sum(a, m, **kwargs):
+    """
+    Returns the sum of the correlations above specified threshold (default 0) for each subsequence in a time series.
+
+    :param a: Time series to compute matrix profile for.
+    :type a: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :param threshold: Correlation threshold [0,1] (Default 0), matches which have a correlation less than the threshold will be ignored
+    :type threshold: float, optional
+    :return: For each subsequence in A, returns the sum of correlations above the specified threshold to other subsequences in A.
+    :rtype: np.ndarray[float64]
+    """
+    ...
+
+
+def abjoin_sum(a, b, m, **kwargs):
+    """
+    For each subsequence in time series a, returns the sum of the correlations to subsequences in time series b above specified threshold (default 0).
+
+    :param a: Time series to compute matrix profile for.
+    :type a: 1D array
+    :param b: Time series to search for matches.
+    :type b: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :param threshold: Correlation threshold [0,1] (Default 0), matches which have a correlation less than the threshold will be ignored
+    :type threshold: float, optional
+    :return: For each subsequence in A, returns the sum of correlations above the specified threshold in B.
+    :rtype: np.ndarray[float64]
+    """
+    ...
+
+
+def selfjoin_knn(a, m, k, **kwargs):
+    """
+    [GPU ONLY, EXPERIMENTAL] Returns the approximate k nearest neighbors for each subsequence in a time series.
+
+    :param a: Time series to compute the KNN matrix profile for.
+    :type a: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :param k: Number of neighbors to return for each subsequence.
+    :type k: int
+    :param threshold: Correlation threshold [0,1] (Default 0), matches which have a correlation less than the threshold will be ignored
+    :type threshold: float, optional
+    :return: List of tuples (col, row, distance) containing the matches (up to K) for each column of the distance matrix, row is the index of the match, and d is the distance between the two subsequences.
+    :rtype: List of tuple[int, int, float]
+    """
+    ...
+
+
+def abjoin_knn(a, b, m, k, **kwargs):
+    """
+    [GPU ONLY, EXPERIMENTAL] For each subsequence in time series A, returns its approximate K nearest neighbors in time series B.
+
+    :param a: Time series to compute the KNN matrix profile for.
+    :type a: 1D array
+    :param b: Time series in which to search for matches.
+    :type b: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :param k: Number of neighbors to return for each subsequence.
+    :type k: int
+    :param threshold: Correlation threshold [0,1] (Default 0), matches which have a correlation less than the threshold will be ignored
+    :type threshold: float, optional
+    :return: List of tuples (col, row, distance) containing the matches (up to K) for each column of the distance matrix, col is the index in A, row is the index in B of the match, and d is the distance between the two subsequences.
+    :rtype: List of tuple[int, int, float]
+    """
+    ...
+
+
+def selfjoin_matrix(a, m, **kwargs):
+    """
+    [EXPERIMENTAL] Returns a pooled version of the distance matrix with HxW of [mheight x mwidth], pooling operation is max() for Pearson Correlation and min() for Euclidean Distance.
+
+    :param a: Time series to compute matrix profile for.
+    :type a: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :param mheight: Height of the pooled distance matrix to output. Default 50.
+    :type mheight: int, optional
+    :param mwidth: Width of the pooled distance matrix to output. Default 50.
+    :type mwidth: int, optional
+    :param threshold: Correlation threshold [0,1] (Default 0), matches which have a correlation less than the threshold will be ignored
+    :type threshold: float, optional
+    :return: A 2D array of height mheight and width mwidth. This is a pooled version of the full distance matrix.
+    :rtype: 2D array
+    """
+    ...
+
+
+def abjoin_matrix(a, b, m, **kwargs):
+    """
+    [EXPERIMENTAL] Returns a pooled version of the distance matrix with HxW of [mheight x mwidth], pooling operation is max() for Pearson Correlation and min() for Euclidean Distance.
+
+    :param a: Time series corresponding to the columns of the distance matrix.
+    :type a: 1D array
+    :param b: Time series corresponding to the rows of the distance matrix.
+    :type b: 1D array
+    :param m: Subsequence length to use for computing the matrix profile.
+    :type m: int
+    :param mheight: Height of the pooled distance matrix to output. Default 50.
+    :type mheight: int, optional
+    :param mwidth: Width of the pooled distance matrix to output. Default 50.
+    :type mwidth: int, optional
+    :param threshold: Correlation threshold [0,1] (Default 0), matches which have a correlation less than the threshold will be ignored
+    :type threshold: float, optional
+    :return: A 2D array of height mheight and width mwidth. This is a pooled version of the full distance matrix.
+    :rtype: 2D array
+    """
+    ...

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-rtd-theme
+setuptools-scm

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,12 +12,13 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../build/'))
 
-# pyscamp is a C extension; mock it so Sphinx can build without a compiled
-# binary in environments where pip install . is unavailable (e.g. RTD preview
-# builds, or if the cmake step fails).
-autodoc_mock_imports = ['pyscamp']
+# docs/pyscamp.py is a pure-Python stub with the real docstrings extracted
+# from src/python/SCAMP_python.cpp. It lets autodoc generate the API docs
+# without requiring a compiled C extension. Inserting docs/ first ensures
+# the stub takes precedence over any installed pyscamp binary.
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../build/'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,11 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../build/'))
 
+# pyscamp is a C extension; mock it so Sphinx can build without a compiled
+# binary in environments where pip install . is unavailable (e.g. RTD preview
+# builds, or if the cmake step fails).
+autodoc_mock_imports = ['pyscamp']
+
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +27,7 @@ copyright = '2024, Zach Zimmerman'
 author = 'Zach Zimmerman'
 
 # The full version, including alpha/beta/rc tags
-release = '4.0.0'
+release = '4.0.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 include(FetchContent)
 FetchContent_Declare(benchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           "v1.6.1"
+  GIT_TAG           "v1.9.0"
 )
 
-set(BENCHMARK_DOWNLOAD_DEPENDENCIES 1)
+# Disable benchmark's own test suite so it does not try to download GoogleTest.
+# GoogleTest's old cmake_minimum_required is rejected by CMake 4.x and the
+# download runs in a subprocess that does not inherit CMAKE_POLICY_VERSION_MINIMUM.
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(benchmark)
 

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 include(FetchContent)
 FetchContent_Declare(benchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           "v1.9.0"
+  GIT_TAG           "v1.9.5"
 )
 
 # Disable benchmark's own test suite so it does not try to download GoogleTest.

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -11,6 +11,19 @@ FetchContent_Declare(benchmark
 # download runs in a subprocess that does not inherit CMAKE_POLICY_VERSION_MINIMUM.
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 
+# Disable benchmark's -Werror. SCAMP's global CMAKE_CXX_FLAGS_RELEASE adds
+# Linux-style flags like -O3 which clang-cl warns about as unused arguments;
+# combined with benchmark's -Werror this turns warnings into hard errors.
+set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "" FORCE)
+
+# On MSVC (cl), benchmark's regex backend detection fails because its test
+# compiles a snippet that gates on __cplusplus, which MSVC reports as 199711L
+# unless /Zc:__cplusplus is set. Pre-cache the result; std::regex is
+# available on every supported MSVC toolchain.
+if(MSVC)
+  set(HAVE_STD_REGEX ON CACHE BOOL "" FORCE)
+endif()
+
 FetchContent_MakeAvailable(benchmark)
 
 add_library(scamp_benchmarks_common "common.cpp")


### PR DESCRIPTION
## Summary

Follow-up fixes for issues discovered after merging PR #136.

**Benchmark (CMake 4):** Google Benchmark v1.6.1 fetches GoogleTest in a cmake subprocess that does not inherit `CMAKE_POLICY_VERSION_MINIMUM`, causing CMake 4.x to reject GoogleTest's old `cmake_minimum_required`. Fix: set `BENCHMARK_ENABLE_TESTING OFF` (GoogleTest not needed for SCAMP benchmarks) and bump Google Benchmark v1.6.1 → v1.9.0 which has native CMake 4 support.

**Read the Docs build:** `pip install .` failed because the pip-installed cmake binary is not on PATH for subprocess calls made by setup.py. Rather than fighting the RTD build environment, drop the pyscamp install step and replace the `autodoc_mock_imports` fallback with `docs/pyscamp.py` — a pure-Python stub containing the real docstrings from `src/python/SCAMP_python.cpp`. Sphinx imports the stub (no cmake, no compiler) and generates complete API documentation. Also adds `setuptools-scm` to `docs/requirements.txt` and bumps the release string to 4.0.1.

**PyPI trusted publishing:** API tokens created before 2FA was enabled are invalidated by PyPI. Switch both publish workflows to OIDC trusted publishing (`id-token: write` permission, no `password:` field). Requires registering a trusted publisher on Test PyPI and PyPI before triggering the workflow.